### PR TITLE
Issue 25 lda proc count from file

### DIFF
--- a/lda-estimate.c
+++ b/lda-estimate.c
@@ -441,7 +441,6 @@ int read_machinefile(char* filename)
     pFile = fopen(filename, "rt");
     while(fgets(line, LINE_SIZE, pFile) != NULL)
     {
-        printf("%s\n", line);
         hostName = strtok(line,":");
         processCountAtHost = atoi(strtok(NULL,":"));
         processCount += processCountAtHost;
@@ -449,7 +448,7 @@ int read_machinefile(char* filename)
 
     fclose(pFile);
 
-    printf("LDA:  Gonna rock this corpus with %d worker processes of raw topic discovery power!\n", processCount);
+    printf("LDA:  Gonna rock this corpus with %d worker processes of raw topic discovery power!!!\n", processCount);
     return processCount;
 }
 
@@ -529,7 +528,6 @@ int main(int argc, char* argv[])
     {
         if (strcmp(argv[OPERATION_ARG], "est")==0)
         {
-            printf("Beginning LDA model estimation.\n\n");
             INITIAL_ALPHA = atof(argv[ALPHA_ARG]);
             NTOPICS = atoi(argv[NTOPICS_ARG]);
             //should read alpha in as a vector instead of from args

--- a/lda-estimate.c
+++ b/lda-estimate.c
@@ -529,6 +529,7 @@ int main(int argc, char* argv[])
     {
         if (strcmp(argv[OPERATION_ARG], "est")==0)
         {
+            printf("Beginning LDA model estimation.\n\n");
             INITIAL_ALPHA = atof(argv[ALPHA_ARG]);
             NTOPICS = atoi(argv[NTOPICS_ARG]);
             //should read alpha in as a vector instead of from args
@@ -552,8 +553,8 @@ int main(int argc, char* argv[])
     }
     else
     {
-        printf("usage : lda est [initial alpha] [k] [settings] [data] [random/seeded/*] [directory]\n");
-        printf("        lda inf [settings] [model] [data] [name]\n");
+        printf("usage : lda est [initial alpha] [k] [settings] [machinefile] [data] [random/seeded/*] [directory]\n");
+        printf("        lda inf [settings] [machinefile] [model] [data] [name]\n");
     }
     return(0);
 }

--- a/lda-estimate.c
+++ b/lda-estimate.c
@@ -441,7 +441,7 @@ int read_machinefile(char* filename)
     pFile = fopen(filename, "r");
     while(fgets(line, LINE_SIZE, pFile) != NULL)
     {
-        sscanf (line, "%s:%d", &hostNameBuffer[0], &processCountAtHost);
+        fscanf (line, "%s:%d\n", &hostNameBuffer[0], &processCountAtHost);
         processCount += processCountAtHost;
     }
 

--- a/lda-estimate.c
+++ b/lda-estimate.c
@@ -503,6 +503,9 @@ int main(int argc, char* argv[])
             char* output_directory = argv[8];
 
 
+            NTOPICS = ntopics; // TODO: get rid of global non-constants
+            INITIAL_ALPHA = alpha; // TODO: get rid of global non-constants
+
             read_settings(settings_path);
             corpus = read_data(corpus_path);
             make_directory(output_directory);

--- a/lda-estimate.c
+++ b/lda-estimate.c
@@ -438,7 +438,6 @@ int read_machinefile(char* filename)
     int processCountAtHost = 0;
     int processCount = 0;
 
-    printf("READING THE MACHINEFILE\n");
     pFile = fopen(filename, "rt");
     while(fgets(line, LINE_SIZE, pFile) != NULL)
     {
@@ -536,11 +535,11 @@ int main(int argc, char* argv[])
             //should read alpha in as a vector instead of from args
             read_settings(argv[SETTINGS_PATH_ARG]);
             int nproc = read_machinefile(argv[MACHINEFILE_PATH_ARG]);
-            //corpus = read_data(argv[DATA_PATH_ARG]);
-            //make_directory(argv[OUPUTDIR_PATH_ARG]);
+            corpus = read_data(argv[DATA_PATH_ARG]);
+            make_directory(argv[OUPUTDIR_PATH_ARG]);
             MPI_Init(&argc, &argv);
 
-            //run_em(argv[INITIALIZATION_ARG], argv[OUPUTDIR_PATH_ARG], corpus, nproc);
+            run_em(argv[INITIALIZATION_ARG], argv[OUPUTDIR_PATH_ARG], corpus, nproc);
             MPI_Finalize();
         }
         if (strcmp(argv[OPERATION_ARG], "inf")==0)

--- a/lda-estimate.c
+++ b/lda-estimate.c
@@ -438,11 +438,11 @@ int read_machinefile(char* filename)
     int processCountAtHost = 0;
     int processCount = 0;
 
-    printf("READING THE MACHINEFILE\n")
+    printf("READING THE MACHINEFILE\n");
     pFile = fopen(filename, "rt");
     while(fgets(line, LINE_SIZE, pFile) != NULL)
     {
-        printf("%s\n", line)
+        printf("%s\n", line);
         sscanf (line, "%s:%d", &hostNameBuffer[0], &processCountAtHost);
         processCount += processCountAtHost;
     }

--- a/lda-estimate.c
+++ b/lda-estimate.c
@@ -438,10 +438,12 @@ int read_machinefile(char* filename)
     int processCountAtHost = 0;
     int processCount = 0;
 
-    pFile = fopen(filename, "r");
+    printf("READING THE MACHINEFILE\n")
+    pFile = fopen(filename, "rt");
     while(fgets(line, LINE_SIZE, pFile) != NULL)
     {
-        fscanf (line, "%s:%d\n", &hostNameBuffer[0], &processCountAtHost);
+        printf("%s\n", line)
+        sscanf (line, "%s:%d", &hostNameBuffer[0], &processCountAtHost);
         processCount += processCountAtHost;
     }
 
@@ -532,11 +534,11 @@ int main(int argc, char* argv[])
             //should read alpha in as a vector instead of from args
             read_settings(argv[SETTINGS_PATH_ARG]);
             int nproc = read_machinefile(argv[MACHINEFILE_PATH_ARG]);
-            corpus = read_data(argv[DATA_PATH_ARG]);
-            make_directory(argv[OUPUTDIR_PATH_ARG]);
+            //corpus = read_data(argv[DATA_PATH_ARG]);
+            //make_directory(argv[OUPUTDIR_PATH_ARG]);
             MPI_Init(&argc, &argv);
 
-            run_em(argv[INITIALIZATION_ARG], argv[OUPUTDIR_PATH_ARG], corpus, nproc);
+            //run_em(argv[INITIALIZATION_ARG], argv[OUPUTDIR_PATH_ARG], corpus, nproc);
             MPI_Finalize();
         }
         if (strcmp(argv[OPERATION_ARG], "inf")==0)

--- a/lda-estimate.c
+++ b/lda-estimate.c
@@ -434,7 +434,7 @@ int read_machinefile(char* filename)
     const int LINE_SIZE = 256;
     char line[LINE_SIZE];
 
-    char hostNameBuffer[LINE_SIZE];
+    char* hostName;
     int processCountAtHost = 0;
     int processCount = 0;
 
@@ -443,7 +443,8 @@ int read_machinefile(char* filename)
     while(fgets(line, LINE_SIZE, pFile) != NULL)
     {
         printf("%s\n", line);
-        sscanf (line, "%s:%d", &hostNameBuffer[0], &processCountAtHost);
+        hostName = strtok(line,":");
+        processCountAtHost = atoi(strtok(NULL,":"));
         processCount += processCountAtHost;
     }
 

--- a/lda-estimate.h
+++ b/lda-estimate.h
@@ -37,7 +37,8 @@ void save_gamma(char* filename,
 
 void run_em(char* start,
             char* directory,
-            corpus* corpus);
+            corpus* corpus,
+            int const nproc);
 
 void read_settings(char* filename);
 

--- a/readme.txt
+++ b/readme.txt
@@ -81,7 +81,7 @@ B. TOPIC ESTIMATION
 
 Estimate the model by executing:
 
-     lda est [alpha] [k] [settings] [data] [random/seeded/*] [directory]
+lda est [alpha] [k] [settings] [#processes] [data] [random/seeded/*] [output directory]
 
 The term [random/seeded/*] > describes how the topics will be
 initialized.  "Random" initializes each topic randomly; "seeded"
@@ -109,6 +109,8 @@ The saved models are in two files:
 The variational posterior Dirichlets are in:
 
      <iteration>.gamma
+
+The # of processes argument is the numer of worker processes used by MPI.
 
 The settings file and data format are described below.
 


### PR DESCRIPTION
This now reads the machinefile to load the number of processes from there at run time.

With this change, it is no longer necessary to recompile LDA when changing the number of hosts or worker processes.

The command line for LDA changes as follows:

  lda est [alpha] [k] [settings] [#processes] [data] [random/seeded/*] [output directory]

analogous changes must be made to the ml_ops script once this change goes in

TESTING

I ran it on the 19731231 smoke test with a few versions of the machine file and # processes changing, all runs worked as expected.
