### PR TITLE
Cleanup globals

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,9 +24,9 @@ MPICC=mpicc
 CFLAGS= -O3 -Wall -g
 LDFLAGS= -lm
 
-LOBJECTS= lda-data.o lda-estimate.o lda-model.o lda-inference.o utils.o cokus.o lda-alpha.o
+LOBJECTS= lda-data.o lda-estimate.o lda-model.o lda-inference.o utils.o cokus.o lda-alpha.o settings.o
 
-LSOURCE= lda-data.c lda-estimate.c lda-model.c lda-inference.c utils.c cokus.c lda-alpha.c
+LSOURCE= lda-data.c lda-estimate.c lda-model.c lda-inference.c utils.c cokus.c lda-alpha.c settings.c
 
 mpi_lda:	$(LOBJECTS)
 	$(CC) $(CFLAGS) $(LOBJECTS) -o lda $(LDFLAGS)

--- a/lda-alpha.h
+++ b/lda-alpha.h
@@ -8,8 +8,8 @@
 #include "lda.h"
 #include "utils.h"
 
-#define NEWTON_THRESH 1e-5
-#define MAX_ALPHA_ITER 1000
+static const double NEWTON_THRESH = 1e-5;
+static const int MAX_ALPHA_ITER = 1000;
 
 double alhood(double a, double ss, int D, int K);
 double d_alhood(double a, double ss, int D, int K);

--- a/lda-data.h
+++ b/lda-data.h
@@ -6,7 +6,7 @@
 
 #include "lda.h"
 
-#define OFFSET 0;                  // offset for reading data
+static const int OFFSET = 0;  // offset for reading data
 
 corpus* read_data(char* data_filename);
 int max_corpus_length(corpus* c);

--- a/lda-estimate.h
+++ b/lda-estimate.h
@@ -22,7 +22,8 @@ double doc_e_step(document* doc,
                   double** phi,
                   lda_model* model,
                   lda_suffstats* ss,
-                  const Settings settings);
+                  int VAR_MAX_ITER,
+                  float VAR_CONVERGED);
 
 void save_gamma(char* filename,
                 double** gamma,

--- a/lda-estimate.h
+++ b/lda-estimate.h
@@ -15,20 +15,14 @@
 #include "lda-alpha.h"
 #include "utils.h"
 #include "cokus.h"
-
-int LAG = 5;
-
-float EM_CONVERGED;
-int EM_MAX_ITER;
-int ESTIMATE_ALPHA;
-double INITIAL_ALPHA;
-int NTOPICS;
+#include "settings.h"
 
 double doc_e_step(document* doc,
                   double* gamma,
                   double** phi,
                   lda_model* model,
-                  lda_suffstats* ss);
+                  lda_suffstats* ss,
+                  const Settings settings);
 
 void save_gamma(char* filename,
                 double** gamma,
@@ -38,13 +32,15 @@ void save_gamma(char* filename,
 void run_em(char* start,
             char* directory,
             corpus* corpus,
-            int const nproc);
+            int const nproc,
+            const Settings settings
+);
 
-void read_settings(char* filename);
 
 void infer(char* model_root,
            char* save,
-           corpus* corpus);
+           corpus* corpus,
+           const Settings settings);
 
 #endif
 

--- a/lda-inference.c
+++ b/lda-inference.c
@@ -24,10 +24,8 @@
  *
  */
 
-double lda_inference(document* doc, lda_model* model, double* var_gamma, double** phi, const Settings settings)
+double lda_inference(document* doc, lda_model* model, double* var_gamma, double** phi, int VAR_MAX_ITER, float VAR_CONVERGED)
 {
-    const int VAR_MAX_ITER = settings.VAR_MAX_ITER;
-    const float VAR_CONVERGED = settings.VAR_CONVERGED;
 
     double converged = 1;
     double phisum = 0, likelihood = 0;

--- a/lda-inference.c
+++ b/lda-inference.c
@@ -18,14 +18,17 @@
 // USA
 
 #include "lda-inference.h"
-
+#include "settings.h"
 /*
  * variational inference
  *
  */
 
-double lda_inference(document* doc, lda_model* model, double* var_gamma, double** phi)
+double lda_inference(document* doc, lda_model* model, double* var_gamma, double** phi, const Settings settings)
 {
+    const int VAR_MAX_ITER = settings.VAR_MAX_ITER;
+    const float VAR_CONVERGED = settings.VAR_CONVERGED;
+
     double converged = 1;
     double phisum = 0, likelihood = 0;
     double likelihood_old = 0, oldphi[model->num_topics];

--- a/lda-inference.h
+++ b/lda-inference.h
@@ -7,7 +7,7 @@
 #include "lda.h"
 #include "utils.h"
 #include "settings.h"
-double lda_inference(document*, lda_model*, double*, double**, const Settings);
+double lda_inference(document*, lda_model*, double*, double**, int VAR_MAX_ITER, float VAR_CONVERGED);
 double compute_likelihood(document*, lda_model*, double**, double*);
 
 #endif

--- a/lda-inference.h
+++ b/lda-inference.h
@@ -6,11 +6,8 @@
 #include <assert.h>
 #include "lda.h"
 #include "utils.h"
-
-float VAR_CONVERGED;
-int VAR_MAX_ITER;
-
-double lda_inference(document*, lda_model*, double*, double**);
+#include "settings.h"
+double lda_inference(document*, lda_model*, double*, double**, const Settings);
 double compute_likelihood(document*, lda_model*, double**, double*);
 
 #endif

--- a/lda-model.h
+++ b/lda-model.h
@@ -8,8 +8,11 @@
 #include "lda-alpha.h"
 #include "cokus.h"
 
-#define myrand() (double) (((unsigned long) randomMT()) / 4294967296.)
-#define NUM_INIT 1
+static inline double myrand() {
+    return (((unsigned long) randomMT()) / 4294967296.0);
+}
+
+static const int NUM_INIT = 1;
 
 void free_lda_model(lda_model*);
 void save_lda_model(lda_model*, char*);

--- a/settings.c
+++ b/settings.c
@@ -12,18 +12,18 @@ Settings* read_settings(const char* filename)
     FILE* fileptr;
     char alpha_action[100];
     fileptr = fopen(filename, "r");
-    fscanf(fileptr, "var max iter %d\n", &pSettings->VAR_MAX_ITER);
-    fscanf(fileptr, "var convergence %f\n", &pSettings->VAR_CONVERGED);
-    fscanf(fileptr, "em max iter %d\n", &pSettings->EM_MAX_ITER);
-    fscanf(fileptr, "em convergence %f\n", &pSettings->EM_CONVERGED);
+    fscanf(fileptr, "var max iter %d\n", &pSettings->var_max_iterations);
+    fscanf(fileptr, "var convergence %f\n", &pSettings->var_converged);
+    fscanf(fileptr, "em max iter %d\n", &pSettings->em_max_iter);
+    fscanf(fileptr, "em convergence %f\n", &pSettings->em_converge);
     fscanf(fileptr, "alpha %s", alpha_action);
     if (strcmp(alpha_action, "fixed")==0)
     {
-        pSettings->ESTIMATE_ALPHA = 0;
+        pSettings->estimate_alpha = 0;
     }
     else
     {
-        pSettings->ESTIMATE_ALPHA = 1;
+        pSettings->estimate_alpha = 1;
     }
     fclose(fileptr);
     return pSettings;

--- a/settings.c
+++ b/settings.c
@@ -1,0 +1,30 @@
+#include "settings.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <memory.h>
+/*
+ * Read settings and return in a newly allocated settings struct.
+ *
+ */
+Settings* read_settings(const char* filename)
+{
+    Settings* pSettings = (Settings *) malloc(sizeof(Settings));
+    FILE* fileptr;
+    char alpha_action[100];
+    fileptr = fopen(filename, "r");
+    fscanf(fileptr, "var max iter %d\n", &pSettings->VAR_MAX_ITER);
+    fscanf(fileptr, "var convergence %f\n", &pSettings->VAR_CONVERGED);
+    fscanf(fileptr, "em max iter %d\n", &pSettings->EM_MAX_ITER);
+    fscanf(fileptr, "em convergence %f\n", &pSettings->EM_CONVERGED);
+    fscanf(fileptr, "alpha %s", alpha_action);
+    if (strcmp(alpha_action, "fixed")==0)
+    {
+        pSettings->ESTIMATE_ALPHA = 0;
+    }
+    else
+    {
+        pSettings->ESTIMATE_ALPHA = 1;
+    }
+    fclose(fileptr);
+    return pSettings;
+}

--- a/settings.h
+++ b/settings.h
@@ -1,0 +1,18 @@
+#ifndef SETTINGS_H
+#define SETTINGS_H
+
+typedef struct
+{
+    float EM_CONVERGED;
+    int EM_MAX_ITER;
+    int ESTIMATE_ALPHA;
+    double INITIAL_ALPHA;
+    int NTOPICS;
+    float VAR_CONVERGED;
+    int VAR_MAX_ITER;
+} Settings;
+
+Settings* read_settings(const char* filename);
+
+#endif
+

--- a/settings.h
+++ b/settings.h
@@ -3,13 +3,13 @@
 
 typedef struct
 {
-    float EM_CONVERGED;
-    int EM_MAX_ITER;
-    int ESTIMATE_ALPHA;
-    double INITIAL_ALPHA;
-    int NTOPICS;
-    float VAR_CONVERGED;
-    int VAR_MAX_ITER;
+    float em_converge;
+    int em_max_iter;
+    int estimate_alpha;
+    double iniitial_alpha;
+    int ntopics;
+    float var_converged;
+    int var_max_iterations;
 } Settings;
 
 Settings* read_settings(const char* filename);


### PR DESCRIPTION
- Global variables replaced by settings object passed into each subroutine. All but VAR_MAX_ITER is read-only anwyay, and the value of VAR_MAX_ITER stays in synch across all processes.
- non-constant variable names de-capitalized
- # defines replaced with static const values and static inline functions
